### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -16,10 +16,10 @@ repos:
       - id: cargo-check
       - id: clippy
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v2.0.1
+    rev: v3.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.8.0
+    rev: v2.12.0
     hooks:
       - id: hadolint


### PR DESCRIPTION
`docker-compose` is removed on newer Ubuntu images. Need the latest version of the `docker-pre-commit` hooks.