### PR TITLE
Add ca-certificate package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "vaultwarden_ldap"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "envy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vaultwarden_ldap"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["ViViDboarder <vividboarder@gmail.com>"]
 edition = "2018"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cargo build --release
 # Use most recent ubuntu LTS release
 FROM ubuntu:24.04
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates 'libssl-dev=3.*' \
+    && apt-get install -y --no-install-recommends 'ca-certificates=20240203' 'libssl-dev=3.*' \
     && rm -rf /var/cache/apt/lists
 COPY --from=builder /usr/src/vaultwarden_ldap/target/release/vaultwarden_ldap /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cargo build --release
 # Use most recent ubuntu LTS release
 FROM ubuntu:24.04
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends 'libssl-dev=3.*' \
+    && apt-get install -y --no-install-recommends ca-certificates 'libssl-dev=3.*' \
     && rm -rf /var/cache/apt/lists
 COPY --from=builder /usr/src/vaultwarden_ldap/target/release/vaultwarden_ldap /usr/local/bin/
 


### PR DESCRIPTION
Add the ca-certificate package because ldaps gives an error when verifying the certificate.

Exemple:
```
Caused by:
    0: Failed to connect to LDAP server
    1: native TLS error: error:16000069:STORE [...] error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1889: (unable to get local issuer certificate)
```